### PR TITLE
doc: add aditional information about auth username

### DIFF
--- a/doc/client.md
+++ b/doc/client.md
@@ -8,7 +8,7 @@ The following parameters are configurable for the API Client:
 | `timeout` | `number` | Timeout for API calls.<br>*Default*: `0` |
 | `httpClientOptions` | `Partial<HttpClientOptions>` | Stable configurable http client options. |
 | `unstableHttpClientOptions` | `any` | Unstable configurable http client options. |
-| `basicAuthUserName` | `string` | The username to use with basic authentication |
+| `basicAuthUserName` | `string` | The username to use with basic authentication (in v5 it would be the SecretKey) |
 | `basicAuthPassword` | `string` | The password to use with basic authentication |
 
 ## HttpClientOptions


### PR DESCRIPTION
It took me a while to find in their documentation that the username should be de SecretKey 😢
Here: [Pagarme Autenticacao](https://docs.pagar.me/reference/autentica%C3%A7%C3%A3o-2)