### PR TITLE
Update type response installments validation

### DIFF
--- a/src/models/getCheckoutCardInstallmentOptionsResponse.ts
+++ b/src/models/getCheckoutCardInstallmentOptionsResponse.ts
@@ -8,14 +8,14 @@ import { nullable, number, object, Schema, string } from '../schema';
 
 export interface GetCheckoutCardInstallmentOptionsResponse {
   /** Número de parcelas */
-  number: string | null;
+  number: number | null;
   /** Valor total da compra */
   total: number | null;
 }
 
 export const getCheckoutCardInstallmentOptionsResponseSchema: Schema<GetCheckoutCardInstallmentOptionsResponse> = object(
   {
-    number: ['number', nullable(string())],
+    number: ['number', nullable(number())],
     total: ['total', nullable(number())],
   }
 );


### PR DESCRIPTION
atualmente, dentro do método de pagamento "checkout", a resposta contida dentro do Caminho: checkouts › 0 › credit_card › parcelas › 0 ' não é mais Nullable<string>, na api a resposta é Nullable<number>