### PR TITLE
Sugestão: `&&` entre as etapas do build

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "node": ">=14.17.0"
   },
   "scripts": {
-    "build": "rimraf dist && tsc -p tsconfig.esm.json & tsc -p tsconfig.cjs.json",
-    "prepare": "rimraf dist && tsc -p tsconfig.esm.json & tsc -p tsconfig.cjs.json",
+    "build": "rimraf dist && tsc -p tsconfig.esm.json && tsc -p tsconfig.cjs.json",
+    "prepare": "rimraf dist && tsc -p tsconfig.esm.json && tsc -p tsconfig.cjs.json",
     "lint": "eslint **/*.ts --ignore-path .eslintignore",
     "lint:fix": "eslint **/*.ts --ignore-path .eslintignore --fix"
   },


### PR DESCRIPTION
# Sugestão: `&&` entre as etapas do build

Olá! Encontrei isso usando o SDK e achei que valia compartilhar.

Os scripts `build` e `prepare` separam os dois últimos comandos com um `&` simples:

```json
"build":   "rimraf dist && tsc -p tsconfig.esm.json & tsc -p tsconfig.cjs.json",
"prepare": "rimraf dist && tsc -p tsconfig.esm.json & tsc -p tsconfig.cjs.json"
```

Como o `&` manda para segundo plano tudo o que está à esquerda dele, o `rimraf dist && tsc esm`
acaba rodando em paralelo com o `tsc cjs` — e o código de saída do script passa a ser só o do
último comando. Na prática:

```sh
$ sh -c 'false & true'; echo $?
0          # a falha some

$ sh -c 'false && true'; echo $?
1          # a falha propaga
```

Isso tem dois efeitos:

1. **Se o build ESM falhar, o script termina com sucesso.** Pesa mais no `prepare`, que roda
   quando alguém instala o pacote a partir de uma URL de git — dá para acabar com um pacote sem
   `dist/esm` e uma instalação verde.
2. **O `rimraf dist` roda junto com o compilador**, podendo apagar arquivo recém-escrito. Os dois
   `tsconfig` também apontam `declarationDir` para o mesmo `dist/types`.

A sugestão é trocar por `&&`:

```json
"build":   "rimraf dist && tsc -p tsconfig.esm.json && tsc -p tsconfig.cjs.json",
"prepare": "rimraf dist && tsc -p tsconfig.esm.json && tsc -p tsconfig.cjs.json"
```

Se o paralelismo era intencional, `rimraf dist && (tsc -p tsconfig.esm.json & tsc -p tsconfig.cjs.json & wait)`
mantém a ideia e ainda falha corretamente — embora o `declarationDir` compartilhado torne a
concorrência arriscada de qualquer jeito.

**Sobre geração de código:** como o `package.json` traz o cabeçalho do APIMatic v3.0, imagino que
o ajuste realmente precise ir no template do gerador, senão ele se perde na próxima geração.
Deixo o PR como registro e patch provisório — fiquem à vontade para fechar e corrigir por lá. 🙂
